### PR TITLE
refactor(BBD-799): Simplify tag selectors

### DIFF
--- a/src/page-size/index.ts
+++ b/src/page-size/index.ts
@@ -6,7 +6,7 @@ import { alias, configurable, tag, Events, Selectors, Store, Tag } from '@storef
 class PageSize {
 
   state: PageSize.State = {
-    pageSizes: this.selectPageSizes(Selectors.pageSizes(this.flux.store.getState())),
+    pageSizes: this.selectPageSizes(this.select(Selectors.pageSizes)),
     onSelect: (index) => this.actions.updatePageSize(this.state.pageSizes[index].value)
   };
 

--- a/test/unit/page-size.ts
+++ b/test/unit/page-size.ts
@@ -8,12 +8,12 @@ const STATE = { y: 'z' };
 suite('PageSize', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias }) => {
   let pageSize: PageSize;
   let selectPageSizesStub: sinon.SinonStub;
-  let pageSizesSelector: sinon.SinonStub;
+  let select: sinon.SinonSpy;
 
   beforeEach(() => {
     PageSize.prototype.flux = <any>{ store: { getState: () => STATE } };
     selectPageSizesStub = stub(PageSize.prototype, 'selectPageSizes');
-    pageSizesSelector = stub(Selectors, 'pageSizes').returns(PAGE_SIZES);
+    select = PageSize.prototype.select = spy(() => PAGE_SIZES);
     pageSize = new PageSize();
   });
   afterEach(() => delete PageSize.prototype.flux);
@@ -26,7 +26,7 @@ suite('PageSize', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlia
       it('should set initial value', () => {
         const sizes = [15, 30, 50];
 
-        expect(pageSizesSelector).to.be.calledWith(STATE);
+        expect(select).to.be.calledWith(Selectors.pageSizes);
         expect(selectPageSizesStub).to.be.calledWith(PAGE_SIZES);
       });
 

--- a/test/unit/page-size.ts
+++ b/test/unit/page-size.ts
@@ -3,7 +3,6 @@ import PageSize from '../../src/page-size';
 import suite from './_suite';
 
 const PAGE_SIZES = [10, 20, 30];
-const STATE = { y: 'z' };
 
 suite('PageSize', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias }) => {
   let pageSize: PageSize;
@@ -11,7 +10,7 @@ suite('PageSize', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlia
   let select: sinon.SinonSpy;
 
   beforeEach(() => {
-    PageSize.prototype.flux = <any>{ store: { getState: () => STATE } };
+    PageSize.prototype.flux = <any>{};
     selectPageSizesStub = stub(PageSize.prototype, 'selectPageSizes');
     select = PageSize.prototype.select = spy(() => PAGE_SIZES);
     pageSize = new PageSize();


### PR DESCRIPTION
The BBD-799 PRs:
* https://github.com/groupby/storefront-collections/pull/16
* https://github.com/groupby/storefront-navigation/pull/31
* https://github.com/groupby/storefront-page-size/pull/15
* https://github.com/groupby/storefront-query/pull/27
* https://github.com/groupby/storefront-recommendations/pull/7
* https://github.com/groupby/storefront-record-count/pull/18
* https://github.com/groupby/storefront-sayt/pull/34
* https://github.com/groupby/storefront-sort/pull/17
* https://github.com/groupby/storefront-structure/pull/37
* https://github.com/groupby/storefront-breadcrumbs/pull/20
