### PR TITLE
fix(SF-1065): Remove padding from interpolated braces in the HTML templates

### DIFF
--- a/src/page-size/index.html
+++ b/src/page-size/index.html
@@ -1,3 +1,3 @@
 <yield>
-  <gb-select options="{ state.pageSizes }" on-select="{ state.onSelect }"></gb-select>
+  <gb-select options="{state.pageSizes}" on-select="{state.onSelect}"></gb-select>
 </yield>


### PR DESCRIPTION
This fixes potential syntax errors coming from Riot.